### PR TITLE
Fix for #49

### DIFF
--- a/custom_components/pronote/pronote_formatter.py
+++ b/custom_components/pronote/pronote_formatter.py
@@ -151,7 +151,7 @@ def format_punishment(punishment) -> dict:
         'giver': punishment.giver,
         'schedule': [{
             'start': schedule.start,
-            'duration': schedule.duration.total_seconds(),
+            'duration': str(schedule.duration),
         } for schedule in punishment.schedule],
         'schedulable': punishment.schedulable,
     }

--- a/custom_components/pronote/pronote_formatter.py
+++ b/custom_components/pronote/pronote_formatter.py
@@ -151,7 +151,7 @@ def format_punishment(punishment) -> dict:
         'giver': punishment.giver,
         'schedule': [{
             'start': schedule.start,
-            'duration': schedule.duration,
+            'duration': schedule.duration.total_seconds(),
         } for schedule in punishment.schedule],
         'schedulable': punishment.schedulable,
     }


### PR DESCRIPTION
Ce changement permet à hass-pronote de convertir le `timedelta` fourni par pronotepy dans l'attribut `duration` de chaque `schedule` en durée exprimée en secondes. Ce qui permet à son tour à HA de sérialiser la donnée dans les attributs du "sensor".