### PR TITLE
Change the pronotepy requirement to the new version in the manifest.json

### DIFF
--- a/custom_components/pronote/manifest.json
+++ b/custom_components/pronote/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/delphiki/hass-pronote/issues",
   "requirements": [
-    "pronotepy==2.14.2"
+    "pronotepy==2.14.3"
   ],
   "version": "0.15.4"
 }

--- a/custom_components/pronote/manifest.json
+++ b/custom_components/pronote/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pronotepy==2.14.3"
   ],
-  "version": "0.15.4"
+  "version": "0.15.5"
 }


### PR DESCRIPTION
The goal is to have the ENT urls working, tested 100% functional. 