### PR TITLE
Update manifest.json to use pronotepy 2.14.5

### DIFF
--- a/custom_components/pronote/manifest.json
+++ b/custom_components/pronote/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/delphiki/hass-pronote/issues",
   "requirements": [
-    "pronotepy @ git+https://github.com/bain3/pronotepy",
+    "pronotepy==2.14.5",
     "python-slugify==8.0.4"
   ],
   "version": "0.15.5"


### PR DESCRIPTION
Mentioned in #123, pronotepy needed updating to work, which happened on the last commit / release.