### PR TITLE
Fix QR code credential persistence by keeping qr_code_uuid in sync

### DIFF
--- a/custom_components/pronote/coordinator.py
+++ b/custom_components/pronote/coordinator.py
@@ -182,6 +182,8 @@ class PronoteDataUpdateCoordinator(TimestampDataUpdateCoordinator):
         
         # + client.password (QR PIN ou jeton) 
         new_data["qr_code_password"] = client.password
+        if new_creds.get("uuid"):
+            new_data["qr_code_uuid"] = new_creds["uuid"]
         
         self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
         

--- a/custom_components/pronote/pronote_helper.py
+++ b/custom_components/pronote/pronote_helper.py
@@ -130,7 +130,7 @@ def get_client_from_qr_code(data) -> pronotepy.Client | pronotepy.ParentClient |
         qr_code_url = data["qr_code_url"]
         qr_code_username = data["qr_code_username"]
         qr_code_password = data["qr_code_password"]
-        qr_code_uuid = data["qr_code_uuid"]
+        qr_code_uuid = data.get("uuid", data["qr_code_uuid"])
         qr_code_account_pin = data.get("account_pin", None)
         qr_code_device_name = data.get("device_name", None)
         qr_code_client_identifier = data.get("client_identifier", None)


### PR DESCRIPTION
This PR improves the robustness of QR code authentication persistence across Home Assistant restarts and HACS updates.

Problem:
- QR code entries currently store both `uuid` and `qr_code_uuid`
- during refresh, `client.export_credentials()` can return a newer `uuid`
- on restart, `token_login()` is rebuilt from `qr_code_uuid`
- if those two values diverge, the integration may reconnect with an outdated UUID and the config entry can fail

Changes:
- prefer the latest stored UUID when rebuilding a QR session:
  `qr_code_uuid = data.get("uuid", data["qr_code_uuid"])`
- keep `qr_code_uuid` synchronized when refreshed credentials provide a new UUID:
  `new_data["qr_code_uuid"] = new_creds["uuid"]`

Expected result:
- QR-based entries become more resilient after restart/update
- less need to recreate entries and rescan QR codes

This particularly helps users with persistent parent-account QR logins.
