### PR TITLE
fix(coordinator): add comment to grade compare keys to avoid missing new_grade events

### DIFF
--- a/custom_components/pronote/coordinator.py
+++ b/custom_components/pronote/coordinator.py
@@ -281,7 +281,7 @@ class PronoteDataUpdateCoordinator(TimestampDataUpdateCoordinator):
         self.compare_data(
             previous_data,
             "grades",
-            ["date", "subject", "grade_out_of"],
+            ["date", "subject", "grade_out_of", "comment"],
             "new_grade",
             format_grade,
         )


### PR DESCRIPTION
## Problem

When multiple grades share the same `date`, `subject`, and `grade_out_of`, 
only the first one triggers a `new_grade` event. Subsequent grades with 
identical values on these three fields are matched against the already-seen 
grade in `previous_data` and silently skipped.

**Example:** two French assessments on the same day, both graded out of 20 — 
only the first one fires an event.

## Fix

Add `comment` (the assessment title) to the `compare_keys` used for grade 
deduplication. Since `comment` reflects the name of the assessment 
(e.g. "Contrôle de lecture", "Exposé"), it reliably distinguishes two 
different grades that would otherwise collide on the previous three fields.

## Change

`custom_components/pronote/coordinator.py` — one line:

```python
# before
["date", "subject", "grade_out_of"]

# after
["date", "subject", "grade_out_of", "comment"]