### PR TITLE
fix(formatter): call Information.content and Information.attachments

### DIFF
--- a/custom_components/pronote/pronote_formatter.py
+++ b/custom_components/pronote/pronote_formatter.py
@@ -230,10 +230,10 @@ def format_information_and_survey(information_and_survey) -> dict:
         "category": information_and_survey.category,
         "survey": information_and_survey.survey,
         "anonymous_response": information_and_survey.anonymous_response,
-        "attachments": format_attachment_list(information_and_survey.attachments),
+        "attachments": format_attachment_list(information_and_survey.attachments()),
         "template": information_and_survey.template,
         "shared_template": information_and_survey.shared_template,
-        "content": information_and_survey.content,
+        "content": information_and_survey.content(),
     }
 
 


### PR DESCRIPTION
Le capteur `information_and_surveys` n'est plus créé, et le journal affiche :

```
Error adding entity sensor.pronote_xxx_information_and_surveys for domain sensor with platform pronote
  File "custom_components/pronote/sensor.py", line 771, in extra_state_attributes
    format_information_and_survey(information_and_survey)
  File "custom_components/pronote/pronote_formatter.py", line 233, in format_information_and_survey
    "attachments": format_attachment_list(information_and_survey.attachments),
  File "custom_components/pronote/pronote_formatter.py", line 57, in format_attachment_list
    for attachment in attachments
TypeError: 'method' object is not iterable
```

### Cause

Le passage de `2.14.6` à `2.15.6` dans 97cc397 a franchi une rupture d'API de
pronotepy, introduite par son commit `0a71eda` (« fix compatibility with PRONOTE
2026.2.4 ») :

| `pronotepy.dataClasses.Information` | 2.14.6 | 2.15.6 |
|---|---|---|
| `content` | `@property` | méthode simple |
| `attachments` | n'existait pas | méthode simple |

`format_information_and_survey` lit toujours les deux comme des attributs :

* ligne 233, `attachments` : lève le `TypeError` ci-dessus, donc le capteur n'est
  jamais ajouté ;
* ligne 236, `content` : aucune erreur, mais l'attribut du capteur reçoit un objet
  méthode au lieu du texte.

Le défaut est resté invisible tant qu'aucune information ni sondage n'était à
formater, ce qui explique qu'il ressorte maintenant que les établissements en
publient.

`Lesson.content` est toujours une `@property` en 2.15.6 et n'est pas touchée.

### Correctif

Deux paires de parenthèses.

Vérifié sur Home Assistant Core 2026.8.3 avec un compte parent sur PRONOTE
2026.2.5.7 : le capteur est de nouveau créé et son attribut `content` contient bien
le texte.

### Remarque

C'est indépendant de la panne de connexion signalée en #172, et cela subsistera une
fois que pronotepy aura publié le correctif de connexion.
