### PR TITLE
Add a Discussions sensor (messaging tab), minimal scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This integration provides several sensors, always prefixed with `pronote_LASTNAM
 | `[...]_delays`                            | delays (current period)                              |
 | `[...]_overall_average`                   | overall average (current period)                     |
 | `[...]_information_and_surveys`           | information and surveys                              |
+| `[...]_discussions`                       | discussions (messaging): count, unread messages       |
 | `[...]_menus`                             | menus (if available)                                 |
 | `[...]_current_period`                    | current period name and dates                        |
 | `[...]_periods`                           | list of all periods                                  |

--- a/custom_components/pronote/const.py
+++ b/custom_components/pronote/const.py
@@ -16,6 +16,10 @@ INFO_SURVEY_LIMIT_MAX_DAYS = 7
 
 HOMEWORK_DESC_MAX_LENGTH = 125
 
+# HA entity attributes have a size limit, so the discussions list exposed as
+# an attribute is capped to the N most recently active discussions.
+DISCUSSIONS_LIMIT = 50
+
 # default values for options
 DEFAULT_REFRESH_INTERVAL = 15
 DEFAULT_ALARM_OFFSET = 60

--- a/custom_components/pronote/coordinator.py
+++ b/custom_components/pronote/coordinator.py
@@ -25,6 +25,7 @@ from .const import (
     LESSON_NEXT_DAY_SEARCH_LIMIT,
     HOMEWORK_MAX_DAYS,
     INFO_SURVEY_LIMIT_MAX_DAYS,
+    DISCUSSIONS_LIMIT,
     EVENT_TYPE,
     DEFAULT_REFRESH_INTERVAL,
     DEFAULT_ALARM_OFFSET,
@@ -146,6 +147,7 @@ class PronoteDataUpdateCoordinator(TimestampDataUpdateCoordinator):
             "punishments": [],
             "menus": [],
             "information_and_surveys": [],
+            "discussions": [],
             "periods": [],
             "current_period": None,
             "previous_periods": [],
@@ -347,6 +349,40 @@ class PronoteDataUpdateCoordinator(TimestampDataUpdateCoordinator):
         except Exception as ex:
             self.data["information_and_surveys"] = None
             _LOGGER.info("Error getting information_and_surveys from pronote: %s", ex)
+
+        # Discussions (Communication > Discussions messaging tab)
+        try:
+            discussions = await self.hass.async_add_executor_job(client.discussions)
+            # Discussion.date is a lazy property (an alias for
+            # Discussion.messages[0].date, i.e. the date of the *first*
+            # message, not the latest one) that makes one extra HTTP request
+            # per discussion the first time it is read. Sorting on it here
+            # would mean one request per discussion on every refresh, which
+            # this integration must avoid, so we deliberately do not touch
+            # it: we keep Pronote's own ordering from the single
+            # "ListeMessagerie" call (already most-recently-active first)
+            # and only cap the list, since HA entity attributes have a size
+            # limit.
+            self.data["discussions"] = discussions[:DISCUSSIONS_LIMIT]
+        except Exception as ex:
+            self.data["discussions"] = None
+            _LOGGER.info("Error getting discussions from pronote: %s", ex)
+
+        # pronotepy's Discussion has no usable unique id (its docstring
+        # advertises one, but it is never actually set), and its "unread"
+        # count changes simply by reading a message in the Pronote app, so
+        # it cannot be used to detect new activity without also firing on
+        # every read. We identify a discussion by (subject, creator): this
+        # fires "new_discussion" when a genuinely new conversation appears,
+        # at the cost of missing a new message posted in an already known
+        # thread (there is no cheap signal for that, see above).
+        self.compare_data(
+            previous_data,
+            "discussions",
+            ["subject", "creator"],
+            "new_discussion",
+            format_discussion,
+        )
 
         # Absences
         self.data["absences"] = await self.hass.async_add_executor_job(

--- a/custom_components/pronote/icons.json
+++ b/custom_components/pronote/icons.json
@@ -32,6 +32,7 @@
       "overall_average": { "default": "mdi:sigma" },
       "overall_average_period": { "default": "mdi:sigma" },
       "information_and_surveys": { "default": "mdi:message-alert-outline" },
+      "discussions": { "default": "mdi:forum" },
       "ical_url": { "default": "mdi:calendar-export" },
       "next_alarm": { "default": "mdi:alarm" },
       "menus": { "default": "mdi:silverware-fork-knife" },

--- a/custom_components/pronote/pronote_formatter.py
+++ b/custom_components/pronote/pronote_formatter.py
@@ -237,6 +237,16 @@ def format_information_and_survey(information_and_survey) -> dict:
     }
 
 
+def format_discussion(discussion) -> dict:
+    return {
+        "subject": discussion.subject,
+        "creator": discussion.creator,
+        "unread": discussion.unread,
+        "closed": discussion.closed,
+        "labels": discussion.labels,
+    }
+
+
 def format_period(period, is_current_period: bool) -> dict:
     return {
         "id": slugify(period.name, separator="_"),

--- a/custom_components/pronote/sensor.py
+++ b/custom_components/pronote/sensor.py
@@ -114,6 +114,7 @@ async def async_setup_entry(
         ),
         # generic sensors
         PronoteInformationAndSurveysSensor(coordinator),
+        PronoteDiscussionsSensor(coordinator),
         PronoteGenericSensor(
             coordinator, "ical_url", "Timetable iCal URL",
             translation_key="ical_url",
@@ -775,6 +776,37 @@ class PronoteInformationAndSurveysSensor(PronoteGenericSensor):
 
         attributes["unread_count"] = unread_count
         attributes["information_and_surveys"] = information_and_surveys
+
+        return attributes
+
+
+class PronoteDiscussionsSensor(PronoteGenericSensor):
+    """Representation of a Pronote sensor."""
+
+    def __init__(self, coordinator) -> None:
+        """Initialize the Pronote sensor."""
+        super().__init__(
+            coordinator,
+            "discussions",
+            "Discussions",
+            len_or_none(coordinator.data["discussions"]),
+            translation_key="discussions",
+        )
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        attributes = super().extra_state_attributes
+        discussions = []
+        unread_count = None
+        if not self.coordinator.data["discussions"] is None:
+            unread_count = 0
+            for discussion in self.coordinator.data["discussions"]:
+                discussions.append(format_discussion(discussion))
+                unread_count += discussion.unread
+
+        attributes["unread_count"] = unread_count
+        attributes["discussions"] = discussions
 
         return attributes
 

--- a/custom_components/pronote/strings.json
+++ b/custom_components/pronote/strings.json
@@ -85,6 +85,7 @@
       "overall_average": { "name": "Overall average" },
       "overall_average_period": { "name": "Overall average {period}" },
       "information_and_surveys": { "name": "Information and surveys" },
+      "discussions": { "name": "Discussions" },
       "ical_url": { "name": "Timetable iCal URL" },
       "next_alarm": { "name": "Next alarm" },
       "menus": { "name": "Menus" },

--- a/custom_components/pronote/translations/en.json
+++ b/custom_components/pronote/translations/en.json
@@ -85,6 +85,7 @@
             "overall_average": { "name": "Overall average" },
             "overall_average_period": { "name": "Overall average {period}" },
             "information_and_surveys": { "name": "Information and surveys" },
+            "discussions": { "name": "Discussions" },
             "ical_url": { "name": "Timetable iCal URL" },
             "next_alarm": { "name": "Next alarm" },
             "menus": { "name": "Menus" },

--- a/custom_components/pronote/translations/fr.json
+++ b/custom_components/pronote/translations/fr.json
@@ -85,6 +85,7 @@
             "overall_average": { "name": "Moyenne générale" },
             "overall_average_period": { "name": "Moyenne générale {period}" },
             "information_and_surveys": { "name": "Informations et sondages" },
+            "discussions": { "name": "Discussions" },
             "ical_url": { "name": "URL iCal de l'emploi du temps" },
             "next_alarm": { "name": "Prochaine alarme" },
             "menus": { "name": "Menus" },


### PR DESCRIPTION
Adds a `discussions` sensor exposing the PRONOTE messaging tab (Communication > Discussions), the only messaging area the integration does not cover yet. Addresses the "at least the unread count" part of #129.

A previous attempt (#168) added a sensor, per-discussion switches and a service (~765 lines) and was closed by its author without maintainer feedback. This PR deliberately covers a much smaller surface, the sensor and its event only, to keep the diff reviewable (87 lines, no new platform, no service, `manifest.json` untouched).

## What it does

- New `discussions` key in the coordinator, fetched through the single `Client.discussions()` call (works on `ParentClient` too), capped to the 50 first entries (`DISCUSSIONS_LIMIT`) because of HA attribute size limits.
- New `PronoteDiscussionsSensor` (`sensor.pronote_LASTNAME_FIRSTNAME_discussions`): state = discussion count, attributes `discussions` (list of `subject`, `creator`, `unread`, `closed`, `labels`) and `unread_count` (sum of `unread`), mirroring the existing `information_and_surveys` sensor.
- New `new_discussion` event fired through the existing `compare_data` helper, like `new_absence`/`new_delay`.
- Icon, `strings.json`, `en`/`fr` translations, README row.

## Deliberately not included

- **No `date` field and no sorting by date**: in pronotepy 2.15.6, `Discussion.date` is a lazy property (alias of `Discussion.messages[0].date`, i.e. the first message) that triggers one extra HTTP request per discussion the first time it is read. Using it would mean one request per discussion on every refresh. The list is therefore left in PRONOTE's own order from the `ListeMessagerie` call and only capped.
- **No `participants`**: also a per-discussion request.
- **No `id`**: despite its docstring, `Discussion` never sets an `id` attribute in 2.15.6. `new_discussion` therefore deduplicates on `(subject, creator)`, and does not use `unread` (which would fire every time a message is simply read).
- No switch or "mark as read"/reply service: out of scope for a first step.

Known limitation: this detects genuinely new conversations, not a new message posted in an already-known thread (no cheap signal for that without the per-discussion request above).

## Tested

Running on a real install (HA 2026.9.0, parent account, QR code login, PRONOTE 2026.2.5.7, pronotepy 2.15.6): the sensor is created and refreshes with the others; the account had no discussion at the time, so state `0` / `unread_count` `0` with an empty list. Other sensors unaffected.

Unrelated, noticed while testing: `information_and_surveys` fails at entity creation on this install (`'NoneType' object has no attribute 'post'`) because `format_information_and_survey` calls the lazy `attachments()` after the coordinator has closed the client session. Not touched here, happy to open a separate issue/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
