### PR TITLE
[story 3] fix(logging): never write credentials to the log

### DIFF
--- a/custom_components/pronote/config_flow.py
+++ b/custom_components/pronote/config_flow.py
@@ -135,8 +135,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
-                # Everything a failed ENT or URL report needs, and no secret:
-                # the password and the PIN are reduced to whether they are set.
+                # No secret: the PIN is reduced to whether it is set.
                 _LOGGER.debug(
                     "Username/password login: url=%s, ent=%s, account_type=%s, pin=%s",
                     user_input.get("url"),

--- a/custom_components/pronote/config_flow.py
+++ b/custom_components/pronote/config_flow.py
@@ -135,7 +135,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
-                _LOGGER.debug("User Input: %s", user_input)
+                # Everything a failed ENT or URL report needs, and no secret:
+                # the password and the PIN are reduced to whether they are set.
+                _LOGGER.debug(
+                    "Username/password login: url=%s, ent=%s, account_type=%s, pin=%s",
+                    user_input.get("url"),
+                    user_input.get("ent"),
+                    self._user_inputs["account_type"],
+                    "set" if user_input.get("account_pin") else "unset",
+                )
                 user_input["account_type"] = self._user_inputs["account_type"]
                 self._user_inputs.update(user_input)
                 client = await self.hass.async_add_executor_job(
@@ -152,7 +160,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.pronote_client = client
 
                 if user_input["account_type"] == "parent":
-                    _LOGGER.debug("_User Inputs UP Parent: %s", self._user_inputs)
                     return await self.async_step_parent()
 
                 return await self.async_step_nickname()
@@ -171,7 +178,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
-                _LOGGER.debug("User Input: %s", self._user_inputs)
                 user_input["account_type"] = self._user_inputs["account_type"]
                 user_input["qr_code_uuid"] = str(uuid.uuid4())
 
@@ -222,7 +228,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         self._user_inputs["child"] = user_input["child"]
-        _LOGGER.debug("Parent Input UP: %s", self._user_inputs)
         return await self.async_step_nickname()
 
     async def async_step_nickname(self, user_input: dict | None = None) -> FlowResult:

--- a/custom_components/pronote/pronote_helper.py
+++ b/custom_components/pronote/pronote_helper.py
@@ -99,8 +99,7 @@ def get_client_from_username_password(
         del client.account_pin
         _LOGGER.debug("Logged in as %s", client.info.name)
     except Exception as err:
-        # debug, not error: called on every refresh, and returning None lets
-        # the coordinator raise UpdateFailed, which logs once on the transition.
+        # debug, not error: called on every refresh.
         _LOGGER.debug(
             "Pronote login failed for %s (%s account%s): %s",
             url,
@@ -144,8 +143,7 @@ def get_client_from_qr_code(data) -> pronotepy.Client | pronotepy.ParentClient |
                 device_name=data.get("device_name", None),
             )
         except Exception:
-            # Unguarded this reached data_entry_flow as "Unknown error occurred"
-            # (#128). No QR payload, no PIN, no token in the message.
+            # Unguarded this reached the config flow as "Unknown error" (#128).
             _LOGGER.exception(
                 "Pronote QR-code enrolment failed (%s account, pin=%s, device=%s)",
                 data["account_type"],
@@ -195,8 +193,7 @@ def get_client_from_qr_code(data) -> pronotepy.Client | pronotepy.ParentClient |
             client_identifier=qr_code_client_identifier,
         )
     except Exception as err:
-        # Same contract as the username/password path: None, and one log line
-        # at debug rather than a traceback on every refresh.
+        # Same contract as the username/password path.
         _LOGGER.debug(
             "Pronote QR-code login failed for %s: %s", qr_code_url, err, exc_info=True
         )

--- a/custom_components/pronote/pronote_helper.py
+++ b/custom_components/pronote/pronote_helper.py
@@ -126,23 +126,47 @@ def get_client_from_qr_code(data) -> pronotepy.Client | pronotepy.ParentClient |
     if "qr_code_json" in data:  # first login from QR Code JSON
 
         # login with qrcode json
-        qr_code_json = json.loads(data["qr_code_json"])
+        try:
+            qr_code_json = json.loads(data["qr_code_json"])
+        except ValueError as err:
+            # A hand-pasted QR payload is the easiest thing to get wrong, and an
+            # unhandled JSONDecodeError surfaces in the config flow as "Unknown
+            # error occurred" with no hint of what to correct. The payload holds
+            # the enrolment secret, so the message stays out of the log.
+            _LOGGER.error("QR-code payload is not valid JSON: %s", err)
+            return None
+
         qr_code_pin = data["qr_code_pin"]
         uuid = data["qr_code_uuid"]
 
         # get the initial client using qr_code
-        client = (
-            pronotepy.ParentClient
-            if data["account_type"] == "parent"
-            else pronotepy.Client
-        ).qrcode_login(
-            qr_code=qr_code_json,
-            pin=qr_code_pin,
-            uuid=uuid,
-            account_pin=data.get("account_pin", None),
-            client_identifier=data.get("client_identifier", None),
-            device_name=data.get("device_name", None),
-        )
+        try:
+            client = (
+                pronotepy.ParentClient
+                if data["account_type"] == "parent"
+                else pronotepy.Client
+            ).qrcode_login(
+                qr_code=qr_code_json,
+                pin=qr_code_pin,
+                uuid=uuid,
+                account_pin=data.get("account_pin", None),
+                client_identifier=data.get("client_identifier", None),
+                device_name=data.get("device_name", None),
+            )
+        except Exception as err:
+            # Unguarded, this escaped to data_entry_flow and the user saw only
+            # "Unknown error occurred": #128 is a raw traceback out of this very
+            # call, an ENT host that would not resolve. Returning None matches
+            # the two other login paths and lets the flow show a form error.
+            _LOGGER.error(
+                "Pronote QR-code enrolment failed (%s account, pin=%s, device=%s): %s",
+                data["account_type"],
+                "set" if data.get("account_pin") else "unset",
+                data.get("device_name"),
+                err,
+                exc_info=True,
+            )
+            return None
 
         qr_code_url = client.pronote_url
         qr_code_username = client.username

--- a/custom_components/pronote/pronote_helper.py
+++ b/custom_components/pronote/pronote_helper.py
@@ -57,8 +57,7 @@ def get_pronote_client(data) -> pronotepy.Client | pronotepy.ParentClient | None
     try:
         client.session_check()
     except Exception as e:
-        # Not fatal on its own - the client is returned and the fetch may still
-        # work - so say so, otherwise this reads as the cause of a later failure.
+        # Not fatal: the client is returned and the fetch may still work.
         _LOGGER.warning(
             "Pronote session check failed, continuing with the client anyway: %s", e
         )
@@ -100,14 +99,8 @@ def get_client_from_username_password(
         del client.account_pin
         _LOGGER.debug("Logged in as %s", client.info.name)
     except Exception as err:
-        # debug, not error: the coordinator calls this on every refresh, so a
-        # password that stopped working would log 96 tracebacks a day at the
-        # default interval. Returning None makes the coordinator raise
-        # UpdateFailed, which logs one ERROR on the success->failure transition
-        # and nothing further - the same shape Home Assistant uses for its own
-        # integrations. exc_info because the useful part is usually the
-        # pronotepy exception type rather than its message, and a traceback
-        # carries no local variables.
+        # debug, not error: called on every refresh, and returning None lets
+        # the coordinator raise UpdateFailed, which logs once on the transition.
         _LOGGER.debug(
             "Pronote login failed for %s (%s account%s): %s",
             url,
@@ -129,10 +122,7 @@ def get_client_from_qr_code(data) -> pronotepy.Client | pronotepy.ParentClient |
         try:
             qr_code_json = json.loads(data["qr_code_json"])
         except ValueError as err:
-            # A hand-pasted QR payload is the easiest thing to get wrong, and an
-            # unhandled JSONDecodeError surfaces in the config flow as "Unknown
-            # error occurred" with no hint of what to correct. The payload holds
-            # the enrolment secret, so the message stays out of the log.
+            # The payload holds the enrolment secret, so it stays out of the log.
             _LOGGER.error("QR-code payload is not valid JSON: %s", err)
             return None
 
@@ -154,14 +144,8 @@ def get_client_from_qr_code(data) -> pronotepy.Client | pronotepy.ParentClient |
                 device_name=data.get("device_name", None),
             )
         except Exception:
-            # Unguarded, this escaped to data_entry_flow and the user saw only
-            # "Unknown error occurred": #128 is a raw traceback out of this very
-            # call, an ENT host that would not resolve. Returning None matches
-            # the two other login paths and lets the flow show a form error.
-            # exception(), not error(..., exc_info=True): the two are
-            # equivalent, and this is the form Home Assistant and the logging
-            # documentation use. Note what is *not* logged - no QR payload, no
-            # PIN, no token - only whether a PIN was supplied at all.
+            # Unguarded this reached data_entry_flow as "Unknown error occurred"
+            # (#128). No QR payload, no PIN, no token in the message.
             _LOGGER.exception(
                 "Pronote QR-code enrolment failed (%s account, pin=%s, device=%s)",
                 data["account_type"],
@@ -186,9 +170,7 @@ def get_client_from_qr_code(data) -> pronotepy.Client | pronotepy.ParentClient |
         qr_code_device_name = data.get("device_name", None)
         qr_code_client_identifier = data.get("client_identifier", None)
 
-    # Enough to tell "no token stored" from "token refused", which is the
-    # question every QR-code report comes down to, and nothing more: the token
-    # itself is a reusable secret and the uuid is useless without it.
+    # Tells "no token stored" from "token refused" without logging the token.
     _LOGGER.debug(
         "QR-code login: url=%s, uuid=%s, token=%d chars, pin=%s, device=%s",
         qr_code_url,
@@ -213,13 +195,8 @@ def get_client_from_qr_code(data) -> pronotepy.Client | pronotepy.ParentClient |
             client_identifier=qr_code_client_identifier,
         )
     except Exception as err:
-        # This path had no handler at all, so the raw exception reached the
-        # coordinator and was reported as an unexpected error with a full
-        # traceback on every refresh. Returning None matches the
-        # username/password path and lets the coordinator raise UpdateFailed,
-        # which logs once on the transition instead. Logged at debug for the
-        # same reason: a revoked token is re-tried every refresh interval, and
-        # this must not become the per-cycle traceback it replaces.
+        # Same contract as the username/password path: None, and one log line
+        # at debug rather than a traceback on every refresh.
         _LOGGER.debug(
             "Pronote QR-code login failed for %s: %s", qr_code_url, err, exc_info=True
         )

--- a/custom_components/pronote/pronote_helper.py
+++ b/custom_components/pronote/pronote_helper.py
@@ -153,18 +153,20 @@ def get_client_from_qr_code(data) -> pronotepy.Client | pronotepy.ParentClient |
                 client_identifier=data.get("client_identifier", None),
                 device_name=data.get("device_name", None),
             )
-        except Exception as err:
+        except Exception:
             # Unguarded, this escaped to data_entry_flow and the user saw only
             # "Unknown error occurred": #128 is a raw traceback out of this very
             # call, an ENT host that would not resolve. Returning None matches
             # the two other login paths and lets the flow show a form error.
-            _LOGGER.error(
-                "Pronote QR-code enrolment failed (%s account, pin=%s, device=%s): %s",
+            # exception(), not error(..., exc_info=True): the two are
+            # equivalent, and this is the form Home Assistant and the logging
+            # documentation use. Note what is *not* logged - no QR payload, no
+            # PIN, no token - only whether a PIN was supplied at all.
+            _LOGGER.exception(
+                "Pronote QR-code enrolment failed (%s account, pin=%s, device=%s)",
                 data["account_type"],
                 "set" if data.get("account_pin") else "unset",
                 data.get("device_name"),
-                err,
-                exc_info=True,
             )
             return None
 

--- a/custom_components/pronote/pronote_helper.py
+++ b/custom_components/pronote/pronote_helper.py
@@ -57,7 +57,11 @@ def get_pronote_client(data) -> pronotepy.Client | pronotepy.ParentClient | None
     try:
         client.session_check()
     except Exception as e:
-        _LOGGER.error("Session check failed: %s", e)
+        # Not fatal on its own - the client is returned and the fetch may still
+        # work - so say so, otherwise this reads as the cause of a later failure.
+        _LOGGER.warning(
+            "Pronote session check failed, continuing with the client anyway: %s", e
+        )
 
     return client
 
@@ -94,9 +98,24 @@ def get_client_from_username_password(
         )
         del ent
         del client.account_pin
-        _LOGGER.info(client.info.name)
+        _LOGGER.debug("Logged in as %s", client.info.name)
     except Exception as err:
-        _LOGGER.critical(err)
+        # debug, not error: the coordinator calls this on every refresh, so a
+        # password that stopped working would log 96 tracebacks a day at the
+        # default interval. Returning None makes the coordinator raise
+        # UpdateFailed, which logs one ERROR on the success->failure transition
+        # and nothing further - the same shape Home Assistant uses for its own
+        # integrations. exc_info because the useful part is usually the
+        # pronotepy exception type rather than its message, and a traceback
+        # carries no local variables.
+        _LOGGER.debug(
+            "Pronote login failed for %s (%s account%s): %s",
+            url,
+            data["account_type"],
+            f", ENT {data['ent']}" if data.get("ent") else "",
+            err,
+            exc_info=True,
+        )
         return None
 
     return client
@@ -141,20 +160,44 @@ def get_client_from_qr_code(data) -> pronotepy.Client | pronotepy.ParentClient |
         qr_code_device_name = data.get("device_name", None)
         qr_code_client_identifier = data.get("client_identifier", None)
 
-    _LOGGER.info(f"Coordinator uses qr_code_username: {qr_code_username}")
-    _LOGGER.info(f"Coordinator uses qr_code_pwd: {qr_code_password}")
-
-    return (
-        pronotepy.ParentClient if data["account_type"] == "parent" else pronotepy.Client
-    ).token_login(
-        pronote_url=qr_code_url,
-        username=qr_code_username,
-        password=qr_code_password,
-        uuid=qr_code_uuid,
-        account_pin=qr_code_account_pin,
-        device_name=qr_code_device_name,
-        client_identifier=qr_code_client_identifier,
+    # Enough to tell "no token stored" from "token refused", which is the
+    # question every QR-code report comes down to, and nothing more: the token
+    # itself is a reusable secret and the uuid is useless without it.
+    _LOGGER.debug(
+        "QR-code login: url=%s, uuid=%s, token=%d chars, pin=%s, device=%s",
+        qr_code_url,
+        qr_code_uuid,
+        len(qr_code_password or ""),
+        "set" if qr_code_account_pin else "unset",
+        qr_code_device_name,
     )
+
+    try:
+        return (
+            pronotepy.ParentClient
+            if data["account_type"] == "parent"
+            else pronotepy.Client
+        ).token_login(
+            pronote_url=qr_code_url,
+            username=qr_code_username,
+            password=qr_code_password,
+            uuid=qr_code_uuid,
+            account_pin=qr_code_account_pin,
+            device_name=qr_code_device_name,
+            client_identifier=qr_code_client_identifier,
+        )
+    except Exception as err:
+        # This path had no handler at all, so the raw exception reached the
+        # coordinator and was reported as an unexpected error with a full
+        # traceback on every refresh. Returning None matches the
+        # username/password path and lets the coordinator raise UpdateFailed,
+        # which logs once on the transition instead. Logged at debug for the
+        # same reason: a revoked token is re-tried every refresh interval, and
+        # this must not become the per-cycle traceback it replaces.
+        _LOGGER.debug(
+            "Pronote QR-code login failed for %s: %s", qr_code_url, err, exc_info=True
+        )
+        return None
 
 
 def get_day_start_at(lessons):

--- a/custom_components/pronote/pronotepy_hotfix.py
+++ b/custom_components/pronote/pronotepy_hotfix.py
@@ -14,39 +14,9 @@ implementation plus a fallback on the raw challenge, so that both migrated and
 non migrated instances keep working. It must be dropped as soon as the fix is
 released upstream, hence the version guard at the bottom of this file.
 
-Attribution
------------
-``_login`` below is a copy of ``ClientBase._login`` from pronotepy 2.15.6,
-with a fallback added on the raw challenge. pronotepy is MIT licensed, which
-permits that copy and asks in return that its notice travel with it - so the
-notice is reproduced here, next to the code it covers, rather than only in a
-dependency list:
-
-    MIT License
-
-    Copyright (c) 2020 bain3
-
-    Permission is hereby granted, free of charge, to any person obtaining a
-    copy of this software and associated documentation files (the "Software"),
-    to deal in the Software without restriction, including without limitation
-    the rights to use, copy, modify, merge, publish, distribute, sublicense,
-    and/or sell copies of the Software, and to permit persons to whom the
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-    DEALINGS IN THE SOFTWARE.
-
-Verbatim from https://github.com/bain3/pronotepy/blob/master/LICENSE at
-2.15.6. Deleting this module when the fix lands upstream deletes the copy,
-and this notice with it.
+``_login`` below is copied from pronotepy 2.15.6 (MIT, Copyright (c) 2020
+bain3 - https://github.com/bain3/pronotepy/blob/master/LICENSE) with a
+fallback added on the raw challenge.
 """
 
 import json

--- a/custom_components/pronote/pronotepy_hotfix.py
+++ b/custom_components/pronote/pronotepy_hotfix.py
@@ -67,7 +67,6 @@ def _login(self) -> bool:
     log.debug("indentification")
 
     # creating the authentification data
-    log.debug(str(idr))
     challenge = idr["dataSec"]["data"]["challenge"]
     e = _Encryption()
     e.aes_set_iv(self.communication.encryption.aes_iv)
@@ -142,7 +141,7 @@ def _login(self) -> bool:
                 self.device_name,
             )
 
-        log.info(f"successfully logged in as {self.username}")
+        log.debug("successfully logged in")
 
         last_conn = auth_response["dataSec"]["data"].get("derniereConnexion")
         self.last_connection = (

--- a/custom_components/pronote/pronotepy_hotfix.py
+++ b/custom_components/pronote/pronotepy_hotfix.py
@@ -13,6 +13,40 @@ This module replaces ``ClientBase._login`` with the upstream 2.15.6
 implementation plus a fallback on the raw challenge, so that both migrated and
 non migrated instances keep working. It must be dropped as soon as the fix is
 released upstream, hence the version guard at the bottom of this file.
+
+Attribution
+-----------
+``_login`` below is a copy of ``ClientBase._login`` from pronotepy 2.15.6,
+with a fallback added on the raw challenge. pronotepy is MIT licensed, which
+permits that copy and asks in return that its notice travel with it - so the
+notice is reproduced here, next to the code it covers, rather than only in a
+dependency list:
+
+    MIT License
+
+    Copyright (c) 2020 bain3
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+Verbatim from https://github.com/bain3/pronotepy/blob/master/LICENSE at
+2.15.6. Deleting this module when the fix lands upstream deletes the copy,
+and this notice with it.
 """
 
 import json

--- a/tests/test_no_credentials_in_log.py
+++ b/tests/test_no_credentials_in_log.py
@@ -1,32 +1,12 @@
 """Tests that no credential reaches the log.
 
-`home-assistant.log` is the file users attach to bug reports, paste into
-issues and hand to whoever is helping them. Anything written there should be
-assumed public. These tests assert the negative - that a specific secret does
-*not* appear - which is the only form of assertion that catches this class of
-regression, because a leak is never in the message the author was thinking
-about.
+`home-assistant.log` is what users attach to bug reports, so these tests
+assert the negative: a given secret does *not* appear. They run at DEBUG, the
+most verbose level a user can enable here.
 
-Every test runs the logger at DEBUG, the most verbose level a user can enable
-for this integration, so nothing is hidden by a level threshold.
-
-Where the guarantee stops
--------------------------
-The handler interpolates the fields it chooses - url, account type, ENT - and
-the exception's own message. So what is guaranteed is that *this integration*
-writes no credential, not that no credential can ever appear: a dependency
-that quoted one in its own message would be passed through.
-
-That boundary was checked rather than assumed. In pronotepy 2.15.6, the
-version this integration pins, no `raise` in `clients.py`, `pronoteAPI.py` or
-the `ent` modules interpolates a username or a password; the `ENTLoginError`
-messages are static or carry only the URL, and none carries the response body.
-An earlier version of this file asserted the stronger property - that a
-credential quoted by the dependency would still not be logged - and it failed,
-correctly: the only way to hold that line is to log the exception type without
-its message, which would cost the one diagnostic that makes a login failure
-reportable at all. If pronotepy ever starts quoting credentials, this is the
-decision to revisit.
+The guarantee covers this integration's own messages, not a dependency's:
+`str(err)` is interpolated. Checked in pronotepy 2.15.6 - no `raise` in
+`clients.py`, `pronoteAPI.py` or `ent/` quotes a username or password.
 """
 
 import json
@@ -103,12 +83,7 @@ class TestUsernamePasswordPath:
         _assert_no_secret(at_debug)
 
     def test_the_failure_is_still_diagnosable(self, at_debug):
-        """Redaction must not leave the user with nothing.
-
-        The point of the branch is that a failure stays reportable: the URL
-        and the account type are what a maintainer needs to tell an ENT
-        problem from a wrong password.
-        """
+        """Redaction must not leave the user with nothing."""
         with patch("pronotepy.ParentClient", side_effect=Exception("boom")):
             get_client_from_username_password(dict(UP_DATA))
 
@@ -142,11 +117,7 @@ class TestTokenPath:
 
 class TestQrCodeEnrolmentPath:
     def test_enrolment_failure_returns_none_instead_of_raising(self, at_debug):
-        """Issue #128: this path had no handler and escaped to the config flow.
-
-        The user saw "Unknown error occurred" and the log carried a raw
-        traceback. Returning None lets the flow show a real form error.
-        """
+        """Issue #128: this path had no handler and escaped to the config flow."""
         with patch("pronotepy.ParentClient") as client:
             client.qrcode_login.side_effect = Exception("ENT host did not resolve")
             assert get_client_from_qr_code(dict(QR_JSON_DATA)) is None

--- a/tests/test_no_credentials_in_log.py
+++ b/tests/test_no_credentials_in_log.py
@@ -1,0 +1,180 @@
+"""Tests that no credential reaches the log.
+
+`home-assistant.log` is the file users attach to bug reports, paste into
+issues and hand to whoever is helping them. Anything written there should be
+assumed public. These tests assert the negative - that a specific secret does
+*not* appear - which is the only form of assertion that catches this class of
+regression, because a leak is never in the message the author was thinking
+about.
+
+Every test runs the logger at DEBUG, the most verbose level a user can enable
+for this integration, so nothing is hidden by a level threshold.
+
+Where the guarantee stops
+-------------------------
+The handler interpolates the fields it chooses - url, account type, ENT - and
+the exception's own message. So what is guaranteed is that *this integration*
+writes no credential, not that no credential can ever appear: a dependency
+that quoted one in its own message would be passed through.
+
+That boundary was checked rather than assumed. In pronotepy 2.15.6, the
+version this integration pins, no `raise` in `clients.py`, `pronoteAPI.py` or
+the `ent` modules interpolates a username or a password; the `ENTLoginError`
+messages are static or carry only the URL, and none carries the response body.
+An earlier version of this file asserted the stronger property - that a
+credential quoted by the dependency would still not be logged - and it failed,
+correctly: the only way to hold that line is to log the exception type without
+its message, which would cost the one diagnostic that makes a login failure
+reportable at all. If pronotepy ever starts quoting credentials, this is the
+decision to revisit.
+"""
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.pronote.pronote_helper import (
+    get_client_from_qr_code,
+    get_client_from_username_password,
+    get_pronote_client,
+)
+
+PASSWORD = "correct-horse-battery-staple"
+QR_TOKEN = "0123456789abcdef0123456789abcdef0123456789abcdef"
+QR_PIN = "4291"
+ACCOUNT_PIN = "1337"
+
+UP_DATA = {
+    "connection_type": "username_password",
+    "url": "https://0000000a.index-education.net/pronote/parent.html",
+    "username": "parent.dupont",
+    "password": PASSWORD,
+    "account_type": "parent",
+    "account_pin": ACCOUNT_PIN,
+    "device_name": "Home Assistant",
+}
+
+TOKEN_DATA = {
+    "connection_type": "qrcode",
+    "qr_code_url": "https://0000000a.index-education.net/pronote/mobile.parent.html",
+    "qr_code_username": "parent.dupont",
+    "qr_code_password": QR_TOKEN,
+    "qr_code_uuid": "8f14e45fceea167a5a36dedd4bea2543",
+    "account_type": "parent",
+    "account_pin": ACCOUNT_PIN,
+    "device_name": "Home Assistant",
+}
+
+QR_JSON_DATA = {
+    "connection_type": "qrcode",
+    "qr_code_json": json.dumps(
+        {"jeton": QR_TOKEN, "login": "parent.dupont", "url": "x"}
+    ),
+    "qr_code_pin": QR_PIN,
+    "qr_code_uuid": "8f14e45fceea167a5a36dedd4bea2543",
+    "account_type": "parent",
+}
+
+# Every secret that must never be written, whatever the code path.
+SECRETS = (PASSWORD, QR_TOKEN, QR_PIN, ACCOUNT_PIN)
+
+
+def _assert_no_secret(caplog):
+    """Fail naming the secret that leaked, not just that one did."""
+    for secret in SECRETS:
+        assert secret not in caplog.text, f"{secret!r} was written to the log"
+
+
+@pytest.fixture
+def at_debug(caplog):
+    """Capture this integration's records at DEBUG."""
+    caplog.set_level(logging.DEBUG, logger="custom_components.pronote.pronote_helper")
+    return caplog
+
+
+class TestUsernamePasswordPath:
+    def test_password_absent_when_the_login_fails(self, at_debug):
+        with patch(
+            "pronotepy.ParentClient", side_effect=Exception("boom")
+        ):
+            assert get_client_from_username_password(dict(UP_DATA)) is None
+        _assert_no_secret(at_debug)
+
+    def test_the_failure_is_still_diagnosable(self, at_debug):
+        """Redaction must not leave the user with nothing.
+
+        The point of the branch is that a failure stays reportable: the URL
+        and the account type are what a maintainer needs to tell an ENT
+        problem from a wrong password.
+        """
+        with patch("pronotepy.ParentClient", side_effect=Exception("boom")):
+            get_client_from_username_password(dict(UP_DATA))
+
+        assert "index-education.net" in at_debug.text
+        assert "parent" in at_debug.text
+
+class TestTokenPath:
+    def test_token_absent_when_the_login_fails(self, at_debug):
+        with patch("pronotepy.ParentClient") as client:
+            client.token_login.side_effect = Exception("token refused")
+            assert get_client_from_qr_code(dict(TOKEN_DATA)) is None
+        _assert_no_secret(at_debug)
+
+    def test_the_token_length_is_logged_instead_of_the_token(self, at_debug):
+        """Length answers "is a token stored at all" without disclosing it."""
+        with patch("pronotepy.ParentClient") as client:
+            client.token_login.side_effect = Exception("token refused")
+            get_client_from_qr_code(dict(TOKEN_DATA))
+
+        assert f"token={len(QR_TOKEN)} chars" in at_debug.text
+        assert QR_TOKEN not in at_debug.text
+
+    def test_pin_is_reported_as_set_or_unset_only(self, at_debug):
+        with patch("pronotepy.ParentClient") as client:
+            client.token_login.side_effect = Exception("token refused")
+            get_client_from_qr_code(dict(TOKEN_DATA))
+
+        assert "pin=set" in at_debug.text
+        assert ACCOUNT_PIN not in at_debug.text
+
+
+class TestQrCodeEnrolmentPath:
+    def test_enrolment_failure_returns_none_instead_of_raising(self, at_debug):
+        """Issue #128: this path had no handler and escaped to the config flow.
+
+        The user saw "Unknown error occurred" and the log carried a raw
+        traceback. Returning None lets the flow show a real form error.
+        """
+        with patch("pronotepy.ParentClient") as client:
+            client.qrcode_login.side_effect = Exception("ENT host did not resolve")
+            assert get_client_from_qr_code(dict(QR_JSON_DATA)) is None
+
+    def test_no_qr_payload_or_pin_in_the_log(self, at_debug):
+        with patch("pronotepy.ParentClient") as client:
+            client.qrcode_login.side_effect = Exception("ENT host did not resolve")
+            get_client_from_qr_code(dict(QR_JSON_DATA))
+
+        _assert_no_secret(at_debug)
+        # The decoded JSON must not be dumped either.
+        assert "jeton" not in at_debug.text
+
+
+class TestGetPronoteClient:
+    def test_no_secret_from_the_dispatching_wrapper(self, at_debug):
+        with patch("pronotepy.ParentClient", side_effect=Exception("boom")):
+            assert get_pronote_client(dict(UP_DATA)) is None
+        _assert_no_secret(at_debug)
+
+    def test_a_failed_session_check_is_not_fatal(self, at_debug):
+        """The client is returned even if the session check complains."""
+        with patch("pronotepy.ParentClient") as client_cls:
+            instance = client_cls.return_value
+            instance.session_check.side_effect = Exception("session stale")
+            instance.info.name = "ENFANT Prenom"
+
+            assert get_pronote_client(dict(UP_DATA)) is instance
+
+        assert "continuing with the client anyway" in at_debug.text
+        _assert_no_secret(at_debug)


### PR DESCRIPTION
Plusieurs appels de journalisation écrivaient le dictionnaire d'entrée complet, mot de passe inclus :

```python
_LOGGER.debug("User Input: %s", user_input)
_LOGGER.info(f"Coordinator uses qr_code_pwd: {qr_code_password}")
```

Le second est en `info`, donc actif par défaut. Dès qu'un utilisateur active le debug pour comprendre un problème de connexion — ce que les issues de ce dépôt demandent souvent — ses identifiants partent dans `home-assistant.log`, et dans les extraits qu'il colle ensuite.

Ce que fait la PR :

- messages ciblés à la place des dictionnaires : URL, ENT, type de compte ; les secrets réduits à `set`/`unset` ou à une longueur ;
- niveaux corrigés : `_LOGGER.critical(err)` sur un échec de connexion devenait 96 traces par jour, il passe en `debug` avec `exc_info` — le coordinateur, lui, lève `UpdateFailed` et signale une fois ;
- deux chemins de connexion (QR code et token) n'avaient aucune garde : l'exception brute remontait au flux de configuration comme « Unknown error occurred » (c'est ce que montre #128). Ils retournent maintenant `None` comme le chemin username/password.

9 tests, qui vérifient qu'aucun message de cette intégration ne contient le mot de passe, le PIN ou le jeton.

Une limite, écrite dans le module : la garantie porte sur nos messages. Si pronotepy lève une exception dont le texte contient une valeur, `str(err)` la recopiera — j'ai vérifié que ce n'est le cas nulle part en 2.15.6, mais ça ne se garantit pas dans le temps.
