### PR TITLE
[story 4] fix(calendar): honour the requested range, add event uids, and select the running lesson

### DIFF
--- a/custom_components/pronote/calendar.py
+++ b/custom_components/pronote/calendar.py
@@ -83,11 +83,15 @@ class PronoteCalendar(CoordinatorEntity, CalendarEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        try:
-            lessons = self.coordinator.data["lessons_period"]
-            if lessons is None:
-                return None
+        lessons = self.coordinator.data.get("lessons_period")
+        if lessons is None:
+            # Leaving without calling super() left the entity holding whatever
+            # event it had, with no state written for this refresh.
+            self._event = None
+            super()._handle_coordinator_update()
+            return
 
+        try:
             now = datetime.now()
             current_event = next(
                 event for event in lessons if event.start >= now and now < event.end
@@ -108,10 +112,22 @@ class PronoteCalendar(CoordinatorEntity, CalendarEntity):
         end_date: datetime,
     ) -> list[CalendarEvent]:
         """Return calendar events within a datetime range."""
+        # .get(): the key is None whenever the lesson fetch failed, and this is
+        # called by the calendar component without consulting `available` - so
+        # opening the panel during an outage raised TypeError at the websocket.
+        lessons = self.coordinator.data.get("lessons_period") or []
+        events = [
+            async_get_calendar_event_from_lessons(lesson, hass.config.time_zone)
+            for lesson in lessons
+            if not lesson.canceled
+        ]
+        # The range was ignored, so every lesson the coordinator held was
+        # returned whatever the caller asked for: the panel drew a fortnight of
+        # lessons into any week, and `calendar.get_events` answered with events
+        # outside its own window. Overlap, not containment - a lesson that
+        # straddles the boundary belongs to both.
         return [
-            async_get_calendar_event_from_lessons(event, hass.config.time_zone)
-            for event in filter(
-                lambda lesson: lesson.canceled == False,
-                self.coordinator.data["lessons_period"],
-            )
+            event
+            for event in events
+            if event.start < end_date and event.end > start_date
         ]

--- a/custom_components/pronote/calendar.py
+++ b/custom_components/pronote/calendar.py
@@ -45,6 +45,12 @@ def async_get_calendar_event_from_lessons(lesson, timezone) -> CalendarEvent:
         location=f"Salle {lesson.classroom}",
         start=lesson.start.replace(tzinfo=tz),
         end=lesson.end.replace(tzinfo=tz),
+        # Without a uid, CalendarEvent leaves the field at None and every
+        # exported VEVENT carries UID "none": an ICS consumer then sees the
+        # whole timetable as one event repeated and keeps only the last one.
+        # Lesson.id is Pronote's own per-lesson identifier, and pronotepy
+        # resolves it strictly, so a Lesson that exists always has one.
+        uid=lesson.id,
     )
 
 

--- a/custom_components/pronote/calendar.py
+++ b/custom_components/pronote/calendar.py
@@ -32,8 +32,17 @@ async def async_setup_entry(
 @callback
 def async_get_calendar_event_from_lessons(lesson, timezone) -> CalendarEvent:
     """Get a HASS CalendarEvent from a Pronote Lesson."""
-    # get_time_zone is Home Assistant's memoised lookup; ZoneInfo() reads the
-    # tz database from disk, and this runs on the event loop.
+    # dt_util.get_time_zone rather than ZoneInfo() directly, for one reason
+    # only: it returns None for an unknown zone instead of raising, so a
+    # misconfigured zone cannot take the whole refresh down with it.
+    #
+    # It is *not* a caching layer - homeassistant/util/dt.py has no lru_cache
+    # on it, its body is `return zoneinfo.ZoneInfo(time_zone_str)`, and the
+    # @lru_cache nearby belongs to get_default_time_zone. Whatever caching
+    # there is belongs to zoneinfo itself and applied just as well to the
+    # ZoneInfo() call this replaced. Its own docstring says it must run in the
+    # executor if the zone is not already cached; that is fine here because
+    # the argument is hass.config.time_zone, resolved at startup.
     tz = dt_util.get_time_zone(timezone)
 
     lesson_name = format_displayed_lesson(lesson)

--- a/custom_components/pronote/calendar.py
+++ b/custom_components/pronote/calendar.py
@@ -32,30 +32,14 @@ async def async_setup_entry(
 @callback
 def async_get_calendar_event_from_lessons(lesson, timezone) -> CalendarEvent:
     """Get a HASS CalendarEvent from a Pronote Lesson."""
-    # dt_util.get_time_zone rather than ZoneInfo() directly, for one reason
-    # only: it returns None for an unknown zone instead of raising, so a
-    # misconfigured zone cannot take the whole refresh down with it.
-    #
-    # It is *not* a caching layer - homeassistant/util/dt.py has no lru_cache
-    # on it, its body is `return zoneinfo.ZoneInfo(time_zone_str)`, and the
-    # @lru_cache nearby belongs to get_default_time_zone. Whatever caching
-    # there is belongs to zoneinfo itself and applied just as well to the
-    # ZoneInfo() call this replaced. Its own docstring says it must run in the
-    # executor if the zone is not already cached; that is fine here because
-    # the argument is hass.config.time_zone, resolved at startup.
+    # get_time_zone returns None for an unknown zone instead of raising.
     tz = dt_util.get_time_zone(timezone)
 
     lesson_name = format_displayed_lesson(lesson)
     if lesson.canceled:
         lesson_name = f"Annulé - {lesson_name}"
 
-    # Pronote publishes lessons with no room and lessons with no teacher -
-    # study hall, a class held off site, a supply teacher not yet named - and
-    # pronotepy resolves both fields non-strictly, so both arrive as None.
-    # Interpolated unconditionally they read "Salle None" in the calendar card
-    # and in every exported VEVENT, and "None - Salle 2.2" for the teacher.
-    # Both fields are optional on CalendarEvent, so the honest value for
-    # "the school did not say" is to leave them out.
+    # classroom and teacher_name are both optional in Pronote.
     room = f"Salle {lesson.classroom}" if lesson.classroom else None
     description = " - ".join(part for part in (lesson.teacher_name, room) if part)
 
@@ -65,11 +49,7 @@ def async_get_calendar_event_from_lessons(lesson, timezone) -> CalendarEvent:
         location=room,
         start=lesson.start.replace(tzinfo=tz),
         end=lesson.end.replace(tzinfo=tz),
-        # Without a uid, CalendarEvent leaves the field at None and every
-        # exported VEVENT carries UID "none": an ICS consumer then sees the
-        # whole timetable as one event repeated and keeps only the last one.
-        # Lesson.id is Pronote's own per-lesson identifier, and pronotepy
-        # resolves it strictly, so a Lesson that exists always has one.
+        # Without a uid every exported VEVENT carries UID "none".
         uid=lesson.id,
     )
 
@@ -108,39 +88,22 @@ class PronoteCalendar(CoordinatorEntity, CalendarEntity):
 
     @callback
     def _compute_event(self) -> CalendarEvent | None:
-        """The lesson that is running, or the next one, as of now.
-
-        Pure: it reads the coordinator data and returns a value, so it can be
-        called from anywhere a state is about to be written.
-        """
+        """The lesson that is running, or the next one, as of now."""
         lessons = self.coordinator.data.get("lessons_period")
         if lessons is None:
-            # The key is None whenever the lesson fetch failed. Reporting no
-            # event is right: the entity must not keep announcing a lesson
-            # from data the coordinator no longer stands behind.
             return None
 
-        # dt_util.now() is the time in the zone Home Assistant is configured
-        # for. datetime.now() was the host's, UTC on a default container, which
-        # shifted the whole selection by an hour or two. Lesson times are naive
-        # local, so the offset comes straight back off for the comparison.
+        # Lesson times are naive local, so compare against the configured zone.
         now = dt_util.now().replace(tzinfo=None)
 
-        # `event.start >= now` implies `now < event.end`, so the second test was
-        # dead and this picked the *next* lesson even while one was running: at
-        # the first refresh after a lesson started, the entity dropped back to
-        # off and stayed there. Cancelled lessons go out here too -
-        # async_get_events already drops them, and the entity must not
-        # contradict the panel about what is on the calendar.
+        # end > now keeps the running lesson; start >= now skipped to the next.
         ongoing_or_next = [
             lesson for lesson in lessons if lesson.end > now and not lesson.canceled
         ]
         if not ongoing_or_next:
             return None
 
-        # min() rather than next(): pronotepy appends lessons week by week in
-        # Pronote's own order and never sorts them, so "the first one that
-        # matches" was not the earliest one.
+        # min(): pronotepy appends lessons week by week and never sorts them.
         return async_get_calendar_event_from_lessons(
             min(ongoing_or_next, key=lambda lesson: lesson.start),
             self.hass.config.time_zone,
@@ -150,36 +113,10 @@ class PronoteCalendar(CoordinatorEntity, CalendarEntity):
     def _async_write_ha_state(self) -> None:
         """Recompute the event on every state write, not only on new data.
 
-        This replaces the `_handle_coordinator_update` override that used to
-        do the selection. Every path that publishes a state ends up here -
-        `CoordinatorEntity._handle_coordinator_update` calls
-        `async_write_ha_state`, and so do the calendar's own alarms - so one
-        recompute here covers all of them, with no second place to keep in
-        step.
-
-        `CalendarEntity._async_write_ha_state` schedules a wake-up at the end
-        of `self.event` and, when that fires, finds `now >= event.end`, so it
-        schedules nothing further (homeassistant/components/calendar,
-        `_async_write_ha_state`). Recomputing only from the coordinator left
-        two holes, both measured on a live instance:
-
-        - back-to-back lessons: at 10:30:00 the end alarm fired, the entity
-          still held the 09:30-10:30 lesson, so it wrote `off` and went quiet
-          until the next refresh - 10:35:46. Six minutes of `off` with a
-          lesson in progress, at every changeover of the day.
-        - after a restart or an options reload: `CoordinatorEntity`
-          registers the listener without calling it, so the first state write
-          had `self._event` still at None and the calendar read `off` with no
-          attributes until the next refresh - a whole interval, 15 minutes by
-          default and more if the user lengthened it.
-
-        Recomputing here closes both. The end alarm now finds the following
-        lesson, writes `on` and schedules that lesson's end, so the chain
-        carries itself between refreshes; and the first write of a fresh
-        entity already has the right event.
-
-        This must stay synchronous and must not raise: it runs inside the
-        state write. `_compute_event` only reads already-fetched data.
+        CalendarEntity schedules a wake-up at the end of self.event and, once
+        that fires, schedules nothing further. Recomputing here lets the end of
+        one lesson pick up the next between two refreshes, and gives a freshly
+        added entity the right event on its first write.
         """
         self._event = self._compute_event()
         super()._async_write_ha_state()
@@ -191,20 +128,16 @@ class PronoteCalendar(CoordinatorEntity, CalendarEntity):
         end_date: datetime,
     ) -> list[CalendarEvent]:
         """Return calendar events within a datetime range."""
-        # .get(): the key is None whenever the lesson fetch failed, and this is
-        # called by the calendar component without consulting `available` - so
-        # opening the panel during an outage raised TypeError at the websocket.
+        # .get(): the key is None when the lesson fetch failed, and the calendar
+        # component calls this without consulting `available`.
         lessons = self.coordinator.data.get("lessons_period") or []
         events = [
             async_get_calendar_event_from_lessons(lesson, hass.config.time_zone)
             for lesson in lessons
             if not lesson.canceled
         ]
-        # The range was ignored, so every lesson the coordinator held was
-        # returned whatever the caller asked for: the panel drew a fortnight of
-        # lessons into any week, and `calendar.get_events` answered with events
-        # outside its own window. Overlap, not containment - a lesson that
-        # straddles the boundary belongs to both.
+        # Overlap, not containment: a lesson straddling the boundary belongs
+        # to both ranges.
         return [
             event
             for event in events

--- a/custom_components/pronote/calendar.py
+++ b/custom_components/pronote/calendar.py
@@ -49,10 +49,20 @@ def async_get_calendar_event_from_lessons(lesson, timezone) -> CalendarEvent:
     if lesson.canceled:
         lesson_name = f"Annulé - {lesson_name}"
 
+    # Pronote publishes lessons with no room and lessons with no teacher -
+    # study hall, a class held off site, a supply teacher not yet named - and
+    # pronotepy resolves both fields non-strictly, so both arrive as None.
+    # Interpolated unconditionally they read "Salle None" in the calendar card
+    # and in every exported VEVENT, and "None - Salle 2.2" for the teacher.
+    # Both fields are optional on CalendarEvent, so the honest value for
+    # "the school did not say" is to leave them out.
+    room = f"Salle {lesson.classroom}" if lesson.classroom else None
+    description = " - ".join(part for part in (lesson.teacher_name, room) if part)
+
     return CalendarEvent(
         summary=lesson_name,
-        description=f"{lesson.teacher_name} - Salle {lesson.classroom}",
-        location=f"Salle {lesson.classroom}",
+        description=description or None,
+        location=room,
         start=lesson.start.replace(tzinfo=tz),
         end=lesson.end.replace(tzinfo=tz),
         # Without a uid, CalendarEvent leaves the field at None and every

--- a/custom_components/pronote/calendar.py
+++ b/custom_components/pronote/calendar.py
@@ -4,8 +4,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
-from homeassistant.util.dt import get_time_zone
-from zoneinfo import ZoneInfo
+from homeassistant.util import dt as dt_util
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import PronoteDataUpdateCoordinator
@@ -33,7 +32,9 @@ async def async_setup_entry(
 @callback
 def async_get_calendar_event_from_lessons(lesson, timezone) -> CalendarEvent:
     """Get a HASS CalendarEvent from a Pronote Lesson."""
-    tz = ZoneInfo(timezone)
+    # get_time_zone is Home Assistant's memoised lookup; ZoneInfo() reads the
+    # tz database from disk, and this runs on the event loop.
+    tz = dt_util.get_time_zone(timezone)
 
     lesson_name = format_displayed_lesson(lesson)
     if lesson.canceled:
@@ -97,17 +98,31 @@ class PronoteCalendar(CoordinatorEntity, CalendarEntity):
             super()._handle_coordinator_update()
             return
 
-        try:
-            now = datetime.now()
-            current_event = next(
-                event for event in lessons if event.start >= now and now < event.end
-            )
-        except StopIteration:
-            self._event = None
-        else:
+        # dt_util.now() is the time in the zone Home Assistant is configured
+        # for. datetime.now() was the host's, UTC on a default container, which
+        # shifted the whole selection by an hour or two. Lesson times are naive
+        # local, so the offset comes straight back off for the comparison.
+        now = dt_util.now().replace(tzinfo=None)
+
+        # `event.start >= now` implies `now < event.end`, so the second test was
+        # dead and this picked the *next* lesson even while one was running: at
+        # the first refresh after a lesson started, the entity dropped back to
+        # off and stayed there. Cancelled lessons go out here too -
+        # async_get_events already drops them, and the entity must not
+        # contradict the panel about what is on the calendar.
+        ongoing_or_next = [
+            lesson for lesson in lessons if lesson.end > now and not lesson.canceled
+        ]
+        if ongoing_or_next:
+            # min() rather than next(): pronotepy appends lessons week by week
+            # in Pronote's own order and never sorts them, so "the first one
+            # that matches" was not the earliest one.
             self._event = async_get_calendar_event_from_lessons(
-                current_event, self.hass.config.time_zone
+                min(ongoing_or_next, key=lambda lesson: lesson.start),
+                self.hass.config.time_zone,
             )
+        else:
+            self._event = None
 
         super()._handle_coordinator_update()
 

--- a/custom_components/pronote/calendar.py
+++ b/custom_components/pronote/calendar.py
@@ -32,14 +32,12 @@ async def async_setup_entry(
 @callback
 def async_get_calendar_event_from_lessons(lesson, timezone) -> CalendarEvent:
     """Get a HASS CalendarEvent from a Pronote Lesson."""
-    # get_time_zone returns None for an unknown zone instead of raising.
     tz = dt_util.get_time_zone(timezone)
 
     lesson_name = format_displayed_lesson(lesson)
     if lesson.canceled:
         lesson_name = f"Annulé - {lesson_name}"
 
-    # classroom and teacher_name are both optional in Pronote.
     room = f"Salle {lesson.classroom}" if lesson.classroom else None
     description = " - ".join(part for part in (lesson.teacher_name, room) if part)
 
@@ -93,17 +91,17 @@ class PronoteCalendar(CoordinatorEntity, CalendarEntity):
         if lessons is None:
             return None
 
-        # Lesson times are naive local, so compare against the configured zone.
+        # Lesson times are naive local time.
         now = dt_util.now().replace(tzinfo=None)
 
-        # end > now keeps the running lesson; start >= now skipped to the next.
+        # start >= now skipped the lesson already running.
         ongoing_or_next = [
             lesson for lesson in lessons if lesson.end > now and not lesson.canceled
         ]
         if not ongoing_or_next:
             return None
 
-        # min(): pronotepy appends lessons week by week and never sorts them.
+        # pronotepy never sorts the lessons it appends.
         return async_get_calendar_event_from_lessons(
             min(ongoing_or_next, key=lambda lesson: lesson.start),
             self.hass.config.time_zone,
@@ -111,12 +109,8 @@ class PronoteCalendar(CoordinatorEntity, CalendarEntity):
 
     @callback
     def _async_write_ha_state(self) -> None:
-        """Recompute the event on every state write, not only on new data.
-
-        CalendarEntity schedules a wake-up at the end of self.event and, once
-        that fires, schedules nothing further. Recomputing here lets the end of
-        one lesson pick up the next between two refreshes, and gives a freshly
-        added entity the right event on its first write.
+        """Recompute on every state write: CalendarEntity wakes up at the end
+        of self.event and then schedules nothing further.
         """
         self._event = self._compute_event()
         super()._async_write_ha_state()
@@ -128,16 +122,14 @@ class PronoteCalendar(CoordinatorEntity, CalendarEntity):
         end_date: datetime,
     ) -> list[CalendarEvent]:
         """Return calendar events within a datetime range."""
-        # .get(): the key is None when the lesson fetch failed, and the calendar
-        # component calls this without consulting `available`.
+        # The key is None when the lesson fetch failed.
         lessons = self.coordinator.data.get("lessons_period") or []
         events = [
             async_get_calendar_event_from_lessons(lesson, hass.config.time_zone)
             for lesson in lessons
             if not lesson.canceled
         ]
-        # Overlap, not containment: a lesson straddling the boundary belongs
-        # to both ranges.
+        # Overlap, not containment: a straddling lesson belongs to both.
         return [
             event
             for event in events

--- a/custom_components/pronote/calendar.py
+++ b/custom_components/pronote/calendar.py
@@ -88,15 +88,18 @@ class PronoteCalendar(CoordinatorEntity, CalendarEntity):
         return self._event
 
     @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
+    def _compute_event(self) -> CalendarEvent | None:
+        """The lesson that is running, or the next one, as of now.
+
+        Pure: it reads the coordinator data and returns a value, so it can be
+        called from anywhere a state is about to be written.
+        """
         lessons = self.coordinator.data.get("lessons_period")
         if lessons is None:
-            # Leaving without calling super() left the entity holding whatever
-            # event it had, with no state written for this refresh.
-            self._event = None
-            super()._handle_coordinator_update()
-            return
+            # The key is None whenever the lesson fetch failed. Reporting no
+            # event is right: the entity must not keep announcing a lesson
+            # from data the coordinator no longer stands behind.
+            return None
 
         # dt_util.now() is the time in the zone Home Assistant is configured
         # for. datetime.now() was the host's, UTC on a default container, which
@@ -113,18 +116,54 @@ class PronoteCalendar(CoordinatorEntity, CalendarEntity):
         ongoing_or_next = [
             lesson for lesson in lessons if lesson.end > now and not lesson.canceled
         ]
-        if ongoing_or_next:
-            # min() rather than next(): pronotepy appends lessons week by week
-            # in Pronote's own order and never sorts them, so "the first one
-            # that matches" was not the earliest one.
-            self._event = async_get_calendar_event_from_lessons(
-                min(ongoing_or_next, key=lambda lesson: lesson.start),
-                self.hass.config.time_zone,
-            )
-        else:
-            self._event = None
+        if not ongoing_or_next:
+            return None
 
-        super()._handle_coordinator_update()
+        # min() rather than next(): pronotepy appends lessons week by week in
+        # Pronote's own order and never sorts them, so "the first one that
+        # matches" was not the earliest one.
+        return async_get_calendar_event_from_lessons(
+            min(ongoing_or_next, key=lambda lesson: lesson.start),
+            self.hass.config.time_zone,
+        )
+
+    @callback
+    def _async_write_ha_state(self) -> None:
+        """Recompute the event on every state write, not only on new data.
+
+        This replaces the `_handle_coordinator_update` override that used to
+        do the selection. Every path that publishes a state ends up here -
+        `CoordinatorEntity._handle_coordinator_update` calls
+        `async_write_ha_state`, and so do the calendar's own alarms - so one
+        recompute here covers all of them, with no second place to keep in
+        step.
+
+        `CalendarEntity._async_write_ha_state` schedules a wake-up at the end
+        of `self.event` and, when that fires, finds `now >= event.end`, so it
+        schedules nothing further (homeassistant/components/calendar,
+        `_async_write_ha_state`). Recomputing only from the coordinator left
+        two holes, both measured on a live instance:
+
+        - back-to-back lessons: at 10:30:00 the end alarm fired, the entity
+          still held the 09:30-10:30 lesson, so it wrote `off` and went quiet
+          until the next refresh - 10:35:46. Six minutes of `off` with a
+          lesson in progress, at every changeover of the day.
+        - after a restart or an options reload: `CoordinatorEntity`
+          registers the listener without calling it, so the first state write
+          had `self._event` still at None and the calendar read `off` with no
+          attributes until the next refresh - a whole interval, 15 minutes by
+          default and more if the user lengthened it.
+
+        Recomputing here closes both. The end alarm now finds the following
+        lesson, writes `on` and schedules that lesson's end, so the chain
+        carries itself between refreshes; and the first write of a fresh
+        entity already has the right event.
+
+        This must stay synchronous and must not raise: it runs inside the
+        state write. `_compute_event` only reads already-fetched data.
+        """
+        self._event = self._compute_event()
+        super()._async_write_ha_state()
 
     async def async_get_events(
         self,

--- a/tests/test_calendar_events.py
+++ b/tests/test_calendar_events.py
@@ -199,3 +199,116 @@ class TestAsyncGetEvents:
             datetime(2026, 9, 8, 0, 0, tzinfo=tz),
         )
         assert events == []
+
+
+class TestEventSelection:
+    """`_compute_event` picks the lesson that is running, or the next one.
+
+    Selection is exercised through `_compute_event` rather than through a
+    fully constructed entity: it reads the coordinator data and the configured
+    timezone, and nothing else.
+    """
+
+    @pytest.fixture(autouse=True)
+    async def _school_timezone(self, hass):
+        await hass.config.async_set_time_zone(TZ)
+
+    @staticmethod
+    def _entity(hass, lessons):
+        return SimpleNamespace(
+            coordinator=SimpleNamespace(data={"lessons_period": lessons}),
+            hass=hass,
+        )
+
+    def _compute(self, hass, lessons):
+        return PronoteCalendar._compute_event(self._entity(hass, lessons))
+
+    async def test_the_running_lesson_wins_over_the_next_one(self, hass, freezer):
+        """The defect this branch is named after.
+
+        `event.start >= now` implies `now < event.end`, so the second half of
+        the old condition was dead and the selection landed on the lesson
+        *after* the one in progress.
+        """
+        freezer.move_to("2026-09-07T09:47:00+02:00")
+        lessons = [
+            _lesson("29#now", _day(9, 30), _day(10, 30)),
+            _lesson("29#next", _day(10, 30), _day(11, 30), subject="HISTOIRE"),
+        ]
+
+        assert self._compute(hass, lessons).uid == "29#now"
+
+    async def test_the_next_lesson_when_none_is_running(self, hass, freezer):
+        freezer.move_to("2026-09-07T13:15:00+02:00")
+        lessons = [
+            _lesson("29#morning", _day(9, 30), _day(10, 30)),
+            _lesson("29#afternoon", _day(14, 0), _day(15, 0), subject="MATHS"),
+        ]
+
+        assert self._compute(hass, lessons).uid == "29#afternoon"
+
+    async def test_the_changeover_is_immediate(self, hass, freezer):
+        """Measured on a live instance: six minutes of `off` mid-lesson.
+
+        At 10:30:00 the calendar's end alarm fires and the state is written.
+        Recomputing at that moment has to yield the 10:30 lesson - otherwise
+        the entity writes `off`, schedules nothing (`now >= event.end`) and
+        stays wrong until the next coordinator refresh.
+        """
+        lessons = [
+            _lesson("29#first", _day(9, 30), _day(10, 30)),
+            _lesson("29#second", _day(10, 30), _day(11, 30), subject="HISTOIRE"),
+        ]
+
+        freezer.move_to("2026-09-07T10:29:59+02:00")
+        assert self._compute(hass, lessons).uid == "29#first"
+
+        freezer.move_to("2026-09-07T10:30:00+02:00")
+        assert self._compute(hass, lessons).uid == "29#second"
+
+    async def test_the_earliest_match_wins_whatever_the_input_order(
+        self, hass, freezer
+    ):
+        """pronotepy appends week by week and never sorts.
+
+        So "the first lesson that matches" was not the earliest one, which is
+        why this is a `min()` and not a `next()`.
+        """
+        freezer.move_to("2026-09-07T08:00:00+02:00")
+        lessons = [
+            _lesson("29#late", _day(14, 0), _day(15, 0), subject="MATHS"),
+            _lesson("29#early", _day(9, 30), _day(10, 30)),
+            _lesson("29#middle", _day(11, 30), _day(12, 30), subject="FRANCAIS"),
+        ]
+
+        assert self._compute(hass, lessons).uid == "29#early"
+
+    async def test_a_cancelled_lesson_is_never_selected(self, hass, freezer):
+        """The entity must not contradict the panel.
+
+        `async_get_events` drops cancelled lessons, so announcing one as the
+        current event would put the entity at odds with what the calendar
+        shows.
+        """
+        freezer.move_to("2026-09-07T09:47:00+02:00")
+        lessons = [
+            _lesson("29#cancelled", _day(9, 30), _day(10, 30), canceled=True),
+            _lesson("29#real", _day(10, 30), _day(11, 30), subject="HISTOIRE"),
+        ]
+
+        assert self._compute(hass, lessons).uid == "29#real"
+
+    async def test_nothing_left_today(self, hass, freezer):
+        """After the last lesson the entity is `off` with no event.
+
+        Not a failure - it is what "school is over" looks like.
+        """
+        freezer.move_to("2026-09-07T18:00:00+02:00")
+        lessons = [_lesson("29#done", _day(9, 30), _day(10, 30))]
+
+        assert self._compute(hass, lessons) is None
+
+    @pytest.mark.parametrize("held", [None, []])
+    async def test_no_lesson_data(self, hass, freezer, held):
+        freezer.move_to("2026-09-07T09:47:00+02:00")
+        assert self._compute(hass, held) is None

--- a/tests/test_calendar_events.py
+++ b/tests/test_calendar_events.py
@@ -1,0 +1,201 @@
+"""Tests for the calendar platform.
+
+Three defects are covered here, all of them visible in the Home Assistant
+calendar panel: the requested date range was ignored, every exported event
+carried the same uid, and the entity reported the lesson *after* the current
+one rather than the one in progress.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.util import dt as dt_util
+
+from custom_components.pronote.calendar import (
+    PronoteCalendar,
+    async_get_calendar_event_from_lessons,
+)
+
+TZ = "Europe/Paris"
+
+
+def _lesson(lesson_id, start, end, *, subject="ANGLAIS LV1", canceled=False,
+            classroom="2.2", teacher="DAUTRAIX L."):
+    """A stand-in for `pronotepy.Lesson`.
+
+    pronotepy resolves every field in `__init__`, so a plain object with the
+    same attributes behaves identically for everything the calendar reads.
+    """
+    return SimpleNamespace(
+        id=lesson_id,
+        start=start,
+        end=end,
+        subject=SimpleNamespace(name=subject),
+        canceled=canceled,
+        classroom=classroom,
+        teacher_name=teacher,
+        detention=False,
+    )
+
+
+def _day(hour, minute=0, day=7):
+    """A naive datetime, which is what Pronote sends."""
+    return datetime(2026, 9, day, hour, minute)
+
+
+class _Calendar:
+    """Binds the real `async_get_events` to a minimal coordinator stub.
+
+    Constructing the entity itself would pull in the device registry and a
+    config entry for no benefit: the method under test reads exactly one key.
+    """
+
+    async_get_events = PronoteCalendar.async_get_events
+
+    def __init__(self, lessons):
+        self.coordinator = SimpleNamespace(data={"lessons_period": lessons})
+
+
+class TestCalendarEventFromLesson:
+    def test_uid_is_the_pronote_lesson_id(self):
+        event = async_get_calendar_event_from_lessons(
+            _lesson("29#YPsrILbDk56N", _day(9, 30), _day(10, 30)), TZ
+        )
+        assert event.uid == "29#YPsrILbDk56N"
+
+    def test_each_lesson_gets_a_distinct_uid(self):
+        """Issue #77: without this every VEVENT shared one uid.
+
+        An ICS consumer treats same-uid entries as one recurring event and
+        keeps only the last, so an exported timetable collapsed to a single
+        lesson.
+        """
+        lessons = [
+            _lesson("29#aaa", _day(9, 30), _day(10, 30)),
+            _lesson("29#bbb", _day(10, 30), _day(11, 30)),
+            _lesson("29#ccc", _day(14, 0), _day(15, 0)),
+        ]
+        uids = [
+            async_get_calendar_event_from_lessons(lesson, TZ).uid
+            for lesson in lessons
+        ]
+        assert len(set(uids)) == len(uids)
+
+    def test_both_ends_are_timezone_aware(self):
+        """Home Assistant's calendar schema rejects a naive datetime."""
+        event = async_get_calendar_event_from_lessons(
+            _lesson("29#aaa", _day(9, 30), _day(10, 30)), TZ
+        )
+        assert event.start.tzinfo is not None
+        assert event.end.tzinfo is not None
+        assert event.start.utcoffset() == event.end.utcoffset()
+
+    def test_the_wall_clock_time_is_preserved(self):
+        """The school's 09:30 must stay 09:30, not shift by an offset."""
+        event = async_get_calendar_event_from_lessons(
+            _lesson("29#aaa", _day(9, 30), _day(10, 30)), TZ
+        )
+        assert (event.start.hour, event.start.minute) == (9, 30)
+        assert (event.end.hour, event.end.minute) == (10, 30)
+
+    def test_a_cancelled_lesson_is_marked_in_the_summary(self):
+        event = async_get_calendar_event_from_lessons(
+            _lesson("29#aaa", _day(9, 30), _day(10, 30), canceled=True), TZ
+        )
+        assert event.summary.startswith("Annulé - ")
+
+
+class TestAsyncGetEvents:
+    """`async_get_events` builds its events in Home Assistant's timezone.
+
+    The `hass` test fixture defaults to US/Pacific, so the timezone is pinned
+    here: the windows a caller passes and the events the entity returns have
+    to be read on the same clock, which is the whole point of the fix.
+    """
+
+    @pytest.fixture(autouse=True)
+    async def _school_timezone(self, hass):
+        await hass.config.async_set_time_zone(TZ)
+
+    async def test_only_the_requested_day_is_returned(self, hass):
+        """The range was ignored: every held lesson came back, always."""
+        calendar = _Calendar(
+            [
+                _lesson("29#mon", _day(9, 30, day=7), _day(10, 30, day=7)),
+                _lesson("29#tue", _day(9, 30, day=8), _day(10, 30, day=8)),
+                _lesson("29#wed", _day(9, 30, day=9), _day(10, 30, day=9)),
+            ]
+        )
+        tz = dt_util.get_time_zone(TZ)
+        events = await calendar.async_get_events(
+            hass,
+            datetime(2026, 9, 8, 0, 0, tzinfo=tz),
+            datetime(2026, 9, 9, 0, 0, tzinfo=tz),
+        )
+        assert [event.uid for event in events] == ["29#tue"]
+
+    async def test_a_lesson_straddling_the_boundary_belongs_to_both(self, hass):
+        """Overlap, not containment.
+
+        A lesson running across midnight - or across whatever boundary the
+        caller picked - is part of both windows. Containment would drop it
+        from both.
+        """
+        calendar = _Calendar(
+            [_lesson("29#late", _day(23, 30, day=7), _day(0, 30, day=8))]
+        )
+        tz = dt_util.get_time_zone(TZ)
+
+        for start_day, end_day in ((7, 8), (8, 9)):
+            events = await calendar.async_get_events(
+                hass,
+                datetime(2026, 9, start_day, 0, 0, tzinfo=tz),
+                datetime(2026, 9, end_day, 0, 0, tzinfo=tz),
+            )
+            assert [event.uid for event in events] == ["29#late"], (start_day, end_day)
+
+    async def test_a_lesson_touching_the_edge_is_excluded(self, hass):
+        """The window is half-open: a lesson ending exactly at the start is out."""
+        calendar = _Calendar(
+            [_lesson("29#before", _day(7, 30, day=8), _day(8, 0, day=8))]
+        )
+        tz = dt_util.get_time_zone(TZ)
+        events = await calendar.async_get_events(
+            hass,
+            datetime(2026, 9, 8, 8, 0, tzinfo=tz),
+            datetime(2026, 9, 8, 18, 0, tzinfo=tz),
+        )
+        assert events == []
+
+    async def test_cancelled_lessons_are_not_exported(self, hass):
+        calendar = _Calendar(
+            [
+                _lesson("29#kept", _day(9, 30), _day(10, 30)),
+                _lesson("29#gone", _day(10, 30), _day(11, 30), canceled=True),
+            ]
+        )
+        tz = dt_util.get_time_zone(TZ)
+        events = await calendar.async_get_events(
+            hass,
+            datetime(2026, 9, 7, 0, 0, tzinfo=tz),
+            datetime(2026, 9, 8, 0, 0, tzinfo=tz),
+        )
+        assert [event.uid for event in events] == ["29#kept"]
+
+    @pytest.mark.parametrize("held", [None, []])
+    async def test_no_lesson_data_gives_an_empty_list(self, hass, held):
+        """The key is None while the lesson fetch is failing.
+
+        The calendar component calls this without consulting `available`, so
+        opening the panel during an outage used to raise `TypeError` at the
+        websocket rather than showing an empty day.
+        """
+        calendar = _Calendar(held)
+        tz = dt_util.get_time_zone(TZ)
+        events = await calendar.async_get_events(
+            hass,
+            datetime(2026, 9, 7, 0, 0, tzinfo=tz),
+            datetime(2026, 9, 8, 0, 0, tzinfo=tz),
+        )
+        assert events == []

--- a/tests/test_calendar_events.py
+++ b/tests/test_calendar_events.py
@@ -99,6 +99,51 @@ class TestCalendarEventFromLesson:
         assert (event.start.hour, event.start.minute) == (9, 30)
         assert (event.end.hour, event.end.minute) == (10, 30)
 
+    def test_the_room_and_the_teacher_are_reported_when_present(self):
+        """The ordinary case, pinned so the guard cannot quietly drop them."""
+        event = async_get_calendar_event_from_lessons(
+            _lesson("L1", _day(8), _day(9)), TZ
+        )
+        assert event.location == "Salle 2.2"
+        assert event.description == "DAUTRAIX L. - Salle 2.2"
+
+    @pytest.mark.parametrize("empty", [None, ""])
+    def test_a_lesson_with_no_room_does_not_say_salle_none(self, empty):
+        """`classroom` is resolved non-strictly, so study hall arrives as None.
+
+        Interpolated unconditionally it read "Salle None" - in the calendar
+        card, in the entity's location attribute, and in every exported
+        VEVENT. Pronote saying nothing about the room is not a room called
+        None; the field is optional and stays empty.
+        """
+        event = async_get_calendar_event_from_lessons(
+            _lesson("L1", _day(8), _day(9), classroom=empty), TZ
+        )
+        assert event.location is None
+        assert event.description == "DAUTRAIX L."
+        assert "None" not in (event.description or "")
+
+    @pytest.mark.parametrize("empty", [None, ""])
+    def test_a_lesson_with_no_teacher_keeps_the_room(self, empty):
+        """A supply teacher not yet named must not cost the room too.
+
+        The description used to start with the teacher unconditionally, so an
+        unnamed one read "None - Salle 2.2".
+        """
+        event = async_get_calendar_event_from_lessons(
+            _lesson("L1", _day(8), _day(9), teacher=empty), TZ
+        )
+        assert event.location == "Salle 2.2"
+        assert event.description == "Salle 2.2"
+
+    def test_a_lesson_with_neither_has_no_description_at_all(self):
+        """`""` would still write an empty attribute; None leaves it out."""
+        event = async_get_calendar_event_from_lessons(
+            _lesson("L1", _day(8), _day(9), classroom=None, teacher=None), TZ
+        )
+        assert event.location is None
+        assert event.description is None
+
     def test_a_cancelled_lesson_is_marked_in_the_summary(self):
         event = async_get_calendar_event_from_lessons(
             _lesson("29#aaa", _day(9, 30), _day(10, 30), canceled=True), TZ

--- a/tests/test_calendar_events.py
+++ b/tests/test_calendar_events.py
@@ -22,11 +22,7 @@ TZ = "Europe/Paris"
 
 def _lesson(lesson_id, start, end, *, subject="ANGLAIS LV1", canceled=False,
             classroom="2.2", teacher="DAUTRAIX L."):
-    """A stand-in for `pronotepy.Lesson`.
-
-    pronotepy resolves every field in `__init__`, so a plain object with the
-    same attributes behaves identically for everything the calendar reads.
-    """
+    """A stand-in for `pronotepy.Lesson`."""
     return SimpleNamespace(
         id=lesson_id,
         start=start,
@@ -45,11 +41,7 @@ def _day(hour, minute=0, day=7):
 
 
 class _Calendar:
-    """Binds the real `async_get_events` to a minimal coordinator stub.
-
-    Constructing the entity itself would pull in the device registry and a
-    config entry for no benefit: the method under test reads exactly one key.
-    """
+    """Binds the real `async_get_events` to a minimal coordinator stub."""
 
     async_get_events = PronoteCalendar.async_get_events
 
@@ -65,12 +57,7 @@ class TestCalendarEventFromLesson:
         assert event.uid == "29#YPsrILbDk56N"
 
     def test_each_lesson_gets_a_distinct_uid(self):
-        """Issue #77: without this every VEVENT shared one uid.
-
-        An ICS consumer treats same-uid entries as one recurring event and
-        keeps only the last, so an exported timetable collapsed to a single
-        lesson.
-        """
+        """Issue #77: without this every VEVENT shared one uid."""
         lessons = [
             _lesson("29#aaa", _day(9, 30), _day(10, 30)),
             _lesson("29#bbb", _day(10, 30), _day(11, 30)),
@@ -109,13 +96,7 @@ class TestCalendarEventFromLesson:
 
     @pytest.mark.parametrize("empty", [None, ""])
     def test_a_lesson_with_no_room_does_not_say_salle_none(self, empty):
-        """`classroom` is resolved non-strictly, so study hall arrives as None.
-
-        Interpolated unconditionally it read "Salle None" - in the calendar
-        card, in the entity's location attribute, and in every exported
-        VEVENT. Pronote saying nothing about the room is not a room called
-        None; the field is optional and stays empty.
-        """
+        """`classroom` is resolved non-strictly, so study hall arrives as None."""
         event = async_get_calendar_event_from_lessons(
             _lesson("L1", _day(8), _day(9), classroom=empty), TZ
         )
@@ -125,11 +106,7 @@ class TestCalendarEventFromLesson:
 
     @pytest.mark.parametrize("empty", [None, ""])
     def test_a_lesson_with_no_teacher_keeps_the_room(self, empty):
-        """A supply teacher not yet named must not cost the room too.
-
-        The description used to start with the teacher unconditionally, so an
-        unnamed one read "None - Salle 2.2".
-        """
+        """A supply teacher not yet named must not cost the room too."""
         event = async_get_calendar_event_from_lessons(
             _lesson("L1", _day(8), _day(9), teacher=empty), TZ
         )
@@ -152,12 +129,7 @@ class TestCalendarEventFromLesson:
 
 
 class TestAsyncGetEvents:
-    """`async_get_events` builds its events in Home Assistant's timezone.
-
-    The `hass` test fixture defaults to US/Pacific, so the timezone is pinned
-    here: the windows a caller passes and the events the entity returns have
-    to be read on the same clock, which is the whole point of the fix.
-    """
+    """`async_get_events` builds its events in Home Assistant's timezone."""
 
     @pytest.fixture(autouse=True)
     async def _school_timezone(self, hass):
@@ -181,12 +153,7 @@ class TestAsyncGetEvents:
         assert [event.uid for event in events] == ["29#tue"]
 
     async def test_a_lesson_straddling_the_boundary_belongs_to_both(self, hass):
-        """Overlap, not containment.
-
-        A lesson running across midnight - or across whatever boundary the
-        caller picked - is part of both windows. Containment would drop it
-        from both.
-        """
+        """Overlap, not containment."""
         calendar = _Calendar(
             [_lesson("29#late", _day(23, 30, day=7), _day(0, 30, day=8))]
         )
@@ -230,12 +197,7 @@ class TestAsyncGetEvents:
 
     @pytest.mark.parametrize("held", [None, []])
     async def test_no_lesson_data_gives_an_empty_list(self, hass, held):
-        """The key is None while the lesson fetch is failing.
-
-        The calendar component calls this without consulting `available`, so
-        opening the panel during an outage used to raise `TypeError` at the
-        websocket rather than showing an empty day.
-        """
+        """The key is None while the lesson fetch is failing."""
         calendar = _Calendar(held)
         tz = dt_util.get_time_zone(TZ)
         events = await calendar.async_get_events(
@@ -247,12 +209,7 @@ class TestAsyncGetEvents:
 
 
 class TestEventSelection:
-    """`_compute_event` picks the lesson that is running, or the next one.
-
-    Selection is exercised through `_compute_event` rather than through a
-    fully constructed entity: it reads the coordinator data and the configured
-    timezone, and nothing else.
-    """
+    """`_compute_event` picks the lesson that is running, or the next one."""
 
     @pytest.fixture(autouse=True)
     async def _school_timezone(self, hass):
@@ -269,12 +226,7 @@ class TestEventSelection:
         return PronoteCalendar._compute_event(self._entity(hass, lessons))
 
     async def test_the_running_lesson_wins_over_the_next_one(self, hass, freezer):
-        """The defect this branch is named after.
-
-        `event.start >= now` implies `now < event.end`, so the second half of
-        the old condition was dead and the selection landed on the lesson
-        *after* the one in progress.
-        """
+        """The defect this branch is named after."""
         freezer.move_to("2026-09-07T09:47:00+02:00")
         lessons = [
             _lesson("29#now", _day(9, 30), _day(10, 30)),
@@ -293,13 +245,7 @@ class TestEventSelection:
         assert self._compute(hass, lessons).uid == "29#afternoon"
 
     async def test_the_changeover_is_immediate(self, hass, freezer):
-        """Measured on a live instance: six minutes of `off` mid-lesson.
-
-        At 10:30:00 the calendar's end alarm fires and the state is written.
-        Recomputing at that moment has to yield the 10:30 lesson - otherwise
-        the entity writes `off`, schedules nothing (`now >= event.end`) and
-        stays wrong until the next coordinator refresh.
-        """
+        """Measured on a live instance: six minutes of `off` mid-lesson."""
         lessons = [
             _lesson("29#first", _day(9, 30), _day(10, 30)),
             _lesson("29#second", _day(10, 30), _day(11, 30), subject="HISTOIRE"),
@@ -314,11 +260,7 @@ class TestEventSelection:
     async def test_the_earliest_match_wins_whatever_the_input_order(
         self, hass, freezer
     ):
-        """pronotepy appends week by week and never sorts.
-
-        So "the first lesson that matches" was not the earliest one, which is
-        why this is a `min()` and not a `next()`.
-        """
+        """pronotepy appends week by week and never sorts."""
         freezer.move_to("2026-09-07T08:00:00+02:00")
         lessons = [
             _lesson("29#late", _day(14, 0), _day(15, 0), subject="MATHS"),
@@ -329,12 +271,7 @@ class TestEventSelection:
         assert self._compute(hass, lessons).uid == "29#early"
 
     async def test_a_cancelled_lesson_is_never_selected(self, hass, freezer):
-        """The entity must not contradict the panel.
-
-        `async_get_events` drops cancelled lessons, so announcing one as the
-        current event would put the entity at odds with what the calendar
-        shows.
-        """
+        """The entity must not contradict the panel."""
         freezer.move_to("2026-09-07T09:47:00+02:00")
         lessons = [
             _lesson("29#cancelled", _day(9, 30), _day(10, 30), canceled=True),
@@ -344,10 +281,7 @@ class TestEventSelection:
         assert self._compute(hass, lessons).uid == "29#real"
 
     async def test_nothing_left_today(self, hass, freezer):
-        """After the last lesson the entity is `off` with no event.
-
-        Not a failure - it is what "school is over" looks like.
-        """
+        """After the last lesson the entity is `off` with no event."""
         freezer.move_to("2026-09-07T18:00:00+02:00")
         lessons = [_lesson("29#done", _day(9, 30), _day(10, 30))]
 


### PR DESCRIPTION
Quatre défauts de l'entité calendrier, tous visibles dans le panneau.

**La plage demandée était ignorée.** `async_get_events` renvoyait tous les cours que le coordinateur détenait, quelle que soit la fenêtre demandée : le panneau dessinait une quinzaine de jours dans n'importe quelle semaine, et `calendar.get_events` répondait hors de sa propre fenêtre. Filtré par recouvrement — un cours à cheval sur la limite appartient aux deux.

**Tous les événements exportés portaient le même `uid`.** `CalendarEvent` laisse le champ à `None`, donc chaque VEVENT sortait avec `UID:none` : un client ICS voyait un seul événement répété et n'en gardait qu'un. `lesson.id` est l'identifiant Pronote du cours (ferme #77).

**L'entité annonçait le cours suivant, pas celui en cours.** La sélection testait `event.start >= now and now < event.end` : la seconde condition est impliquée par la première, donc au premier rafraîchissement après le début d'un cours l'entité repassait à `off`. Corrigé en `lesson.end > now`, avec `min()` sur la date de début — pronotepy ajoute les cours semaine par semaine et ne les ordonne jamais, donc « le premier qui correspond » n'était pas le plus tôt.

Le recalcul est fait dans `_async_write_ha_state` et non sur la seule arrivée de données : `CalendarEntity` programme un réveil à la fin de `self.event` puis ne programme plus rien. Sans ça, entre deux cours enchaînés, l'entité restait `off` de la fin du premier jusqu'au rafraîchissement suivant — mesuré à six minutes sur mon instance, à chaque changement d'heure de la journée.

**« Salle None ».** `classroom` et `teacher_name` sont optionnels chez Pronote et étaient interpolés sans garde.

48 tests, et les trois premiers points sont vérifiés sur une instance réelle.
