### PR TITLE
[story 0] chore: add an MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 delphiki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Le dépôt n'a pas de fichier `LICENSE` : l'API GitHub renvoie `license: null`. Sans licence, quelqu'un qui veut réutiliser le code ou proposer une correction n'a pas de cadre — et le contrôle `license` de l'action HACS échoue pour la même raison.

MIT est proposée parce qu'elle est simple et courante ici (`pronotepy` est en MIT, Home Assistant en Apache-2.0), mais **le choix est le vôtre**. C'est pour ça que le fichier est seul dans sa PR : à refuser, ou à accepter avec une autre licence.

21 lignes, un fichier. GitHub ne détecte une licence que sur la branche par défaut, donc le contrôle HACS ne passera au vert qu'après la fusion.
